### PR TITLE
updated compose to use two bind mounts

### DIFF
--- a/Scripts/cli/compose.yaml
+++ b/Scripts/cli/compose.yaml
@@ -11,8 +11,11 @@ services:
     #CREATES THE BIND MOUNTS FROM HOST MACHINE TO CONTAINER.
     volumes:
       - type: bind
-        source: ./supra_configs
+        source: ./supra/configs
         target: /supra/configs
+      - type: bind
+        source: ./supra/move_workspace
+        target: /supra/move_workspace
     #ALLOCATES A PSEUDO-TTY
     tty: true
     #SHARE THE HOST NETWORK


### PR DESCRIPTION
Splits bindmount into two

/configs for profiles/logs
/move_workspace for move projects

Improves the setup process by removing the manual creation of workspace directory and provides better file structure