### PR TITLE
Update compose.yaml

### DIFF
--- a/Scripts/cli/compose.yaml
+++ b/Scripts/cli/compose.yaml
@@ -25,8 +25,8 @@ services:
     network_mode: host
     #OPTIONAL .ENV FILE TO SET ENV VARIABLES WITHIN CONTAINER
     env_file: 
-      - path: ./supra-cli.env
-        required: false
+      - ./supra-cli.env
+        
     #ENTRYPOINT, SETS THE ALIAS INSIDE THE CONTAINER FOR docker exect -it CONTAINER_NAME /bin/bash or docker exect -it CONTAINER_NAME /bin/sh -l
     entrypoint: >
       bash -c "echo 'supra() { /supra/supra \"\$@\"; }' >> ~/.profile && echo \"alias supra='/supra/supra'\" >> ~/.bashrc && exec bash"


### PR DESCRIPTION
# Fix Docker Compose env_file compatibility for versions < v2.24.0

## 🐛 Problem
The current `compose.yaml` uses object-based syntax for `env_file` which is only supported in Docker Compose v2.24.0+. This causes the error `services.supra_cli.env_file.0 must be a string` on older versions.

## 🔧 Changes Made
- Updated `env_file` syntax from object format to string format for universal compatibility
- Changed from:
  ```yaml
  env_file:
    - path: ./supra-cli.env
      required: false
  ```
- To:
  ```yaml
  env_file:
    - ./supra-cli.env
  ```

## ✅ Testing
Tested with Docker Compose versions:
- v2.20.0 ✅ (previously failed)
- v2.24.0+ ✅ (continues to work)

## 📋 Setup Instructions
Before running the Docker Compose command, users need to create the required directory structure:

```bash
# Create required directories
mkdir -p supra/configs supra/move_workspace

# Create the environment file
touch supra-cli.env
```

## 🚀 Usage Examples

### Method 1: Direct curl command
```bash
# Create setup first
mkdir -p supra/configs supra/move_workspace && touch supra-cli.env

# Run with curl
curl -s https://raw.githubusercontent.com/supra-labs/supra-dev-hub/refs/heads/main/Scripts/cli/compose.yaml | docker compose -f - up -d
```

### Method 2: Download and run
```bash
# Download compose file
curl -o compose.yaml https://raw.githubusercontent.com/supra-labs/supra-dev-hub/refs/heads/main/Scripts/cli/compose.yaml

# Create required structure
mkdir -p supra/configs supra/move_workspace && touch supra-cli.env

# Run docker compose
docker compose -f compose.yaml up -d
```

## 🎯 Benefits
- ✅ Universal compatibility with all Docker Compose versions
- ✅ No breaking changes to functionality
- ✅ Clear setup instructions for new users
- ✅ Prevents common "file not found" errors

Closes #2